### PR TITLE
Update cook-docs install to work with pages

### DIFF
--- a/hooks/cookDocs.py
+++ b/hooks/cookDocs.py
@@ -5,7 +5,7 @@ from os import getenv
 class CookDocs:
 	def __init__(self) -> None:
 		self.download()
-		self.reshimd()
+		self.reshim()
 		self.run()
 
 	def reshim(self) -> None:

--- a/hooks/cookDocs.py
+++ b/hooks/cookDocs.py
@@ -22,7 +22,7 @@ class CookDocs:
 		if (getenv('GITHUB_ACTIONS') != None and bool(getenv('GITHUB_ACTIONS')) == True):
 			gopath = ''
 		elif (getenv('CF_PAGES') != None and int(getenv('CF_PAGES')) == 1):
-			gopath = '$GOPATH/bin/'
+			gopath = ''
 
 		ls1 = '$GOBIN'
 		print(f"Before {ls1}")

--- a/hooks/cookDocs.py
+++ b/hooks/cookDocs.py
@@ -5,14 +5,16 @@ from os import getenv
 class CookDocs:
 	def __init__(self) -> None:
 		self.download()
+		self.reshimd()
 		self.run()
 
+	def reshim(self) -> None:
+		reshim_attempt = run("asdf reshim golang", capture_output=True, shell=True, check=False, text=True)
+		print(reshim_attempt.stdout, flush=True)
+		print(reshim_attempt.stderr, flush=True)
+	
 	def download(self) -> None:
-		goInstallAttempt = run([
-			"go", "install", "github.com/nicholaswilde/cook-docs/cmd/cook-docs@latest",
-			"&&",
-			"asdf", "reshim", "golang"
-		], capture_output=True, shell=True, check=True, text=True)
+		goInstallAttempt = run(["go", "install", "github.com/nicholaswilde/cook-docs/cmd/cook-docs@latest"], capture_output=True, check=True, text=True)
 		print(goInstallAttempt.stdout, flush=True)
 		print(goInstallAttempt.stderr, flush=True)
 

--- a/hooks/cookDocs.py
+++ b/hooks/cookDocs.py
@@ -5,7 +5,8 @@ from os import getenv
 class CookDocs:
 	def __init__(self) -> None:
 		self.download()
-		self.reshim()
+		if (getenv('CF_PAGES') != None and int(getenv('CF_PAGES')) == 1):
+			self.reshim()
 		self.run()
 
 	def reshim(self) -> None:

--- a/hooks/cookDocs.py
+++ b/hooks/cookDocs.py
@@ -8,7 +8,11 @@ class CookDocs:
 		self.run()
 
 	def download(self) -> None:
-		goInstallAttempt = run(["go", "install", "github.com/nicholaswilde/cook-docs/cmd/cook-docs@latest"], capture_output=True, check=True, text=True)
+		goInstallAttempt = run([
+			"go", "install", "github.com/nicholaswilde/cook-docs/cmd/cook-docs@latest",
+			"&&",
+			"asdf", "reshim", "golang"
+		], capture_output=True, shell=True, check=True, text=True)
 		print(goInstallAttempt.stdout, flush=True)
 		print(goInstallAttempt.stderr, flush=True)
 


### PR DESCRIPTION
Here's the code required to make this project work on Pages today. I'll see if we can automatically re-shim golang after a `go install ...` adds binaries to its path